### PR TITLE
fix: set to null undefined keys

### DIFF
--- a/spec/aggragateSpec.js
+++ b/spec/aggragateSpec.js
@@ -43,6 +43,18 @@ describe('Aggragation Spec', function() {
   });
 
   /**
+   * Test reset method
+   */
+  it ('should set to null keys that are not defined', function() {
+    aggregator.aggregate({impressions: 1, clicks: 1, campaingId: 1});
+    aggregator.aggregate({impressions: 1, clicks: 1, campaingId: 1});
+
+    var res = aggregator.results();
+    
+    expect(res['be0d5b49d4e93d78b22427ce4b4d17c3'].adId).toEqual(null);
+  });
+
+  /**
    * Test number of results
    */
   it ('should return 2 rows in total', function() {

--- a/src/index.js
+++ b/src/index.js
@@ -36,7 +36,7 @@ module.exports = function () {
     // Add metadata
     for (var i = 0, len = config.groupBy.length; i < len; i++) {
       var field = config.groupBy[i];
-      increment[field] = rawRecord[field];
+      increment[field] = rawRecord[field] || null;
     }
 
     return increment;

--- a/src/index.js
+++ b/src/index.js
@@ -36,7 +36,7 @@ module.exports = function () {
     // Add metadata
     for (var i = 0, len = config.groupBy.length; i < len; i++) {
       var field = config.groupBy[i];
-      increment[field] = rawRecord[field] || null;
+      increment[field] = rawRecord[field] === undefined ? null : rawRecord[field];
     }
 
     return increment;


### PR DESCRIPTION
En base a los comentarios de https://github.com/HwdGroup/aws-resources/pull/123#discussion_r111163970 agrego una condición de que si la key es undefined la seteo como null.

- [x] Easy to rollback to the previous state
- [x] Works fine with the old state in parallel (backward compatible)
- [x] It doesn't depend on other branches/PR