### PR TITLE
fix: keep groupBy order of properties when hashing

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -96,14 +96,12 @@ module.exports = function () {
    * @returns {String} MD5 string
    */
   function makeHash(record) {
-    var objToHash = {};
-    for (var item in record) {
-      for (var i = 0, gLen = config.groupBy.length; i < gLen; i++) {
-        if (item === config.groupBy[i]) {
-          objToHash[item] = record[item];
-        }
+    var objToHash = config.groupBy.reduce(function(acc, field) {
+      if (record.hasOwnProperty(field)) {
+        acc[field] = record[field];
       }
-    }
+      return acc;
+    }, {});
 
     return crypto.createHash('md5')
       .update(JSON.stringify(objToHash))


### PR DESCRIPTION
Partially fixes: https://github.com/HwdGroup/analytics-workers/issues/2

Changes:

* keep groupBy order of properties when hashing

Benchmarks:

```
CURRENT
Started
Finished at: 7,37241127
100000 lines processed
Benchmark took 7 seconds or 700000000037241127 nanoseconds

AFTER CHANGES
Started
Finished at: 6,947852843
100000 lines processed
Benchmark took 6 seconds or 6000000000947852843 nanoseconds
```

Tests:

```
Started
...............


15 specs, 0 failures
Finished in 0.03 seconds
```

Related to: https://github.com/HwdGroup/flow/pull/6